### PR TITLE
Replace static weight/height thresholds with pokemon-relative comparisons

### DIFF
--- a/src/app/create/page.tsx
+++ b/src/app/create/page.tsx
@@ -9,6 +9,7 @@ import {
   getLabelForCategoryId,
   getAllMoveNames,
   getAllAbilityNames,
+  getAllPokemonNames,
 } from "@/data/pokemon";
 import PokemonAutocomplete from "@/components/PokemonAutocomplete";
 
@@ -28,12 +29,16 @@ export default function CreatePage() {
   const [submitting, setSubmitting] = useState(false);
   const [moveSearch, setMoveSearch] = useState("");
   const [abilitySearch, setAbilitySearch] = useState("");
+  const [weightPokemonSearch, setWeightPokemonSearch] = useState("");
+  const [heightPokemonSearch, setHeightPokemonSearch] = useState("");
 
   // Reset search inputs when opening a new picker slot
   useEffect(() => {
     if (pickingSlot) {
       setMoveSearch("");
       setAbilitySearch("");
+      setWeightPokemonSearch("");
+      setHeightPokemonSearch("");
     }
   }, [pickingSlot?.axis, pickingSlot?.index]); // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -46,9 +51,17 @@ export default function CreatePage() {
   const usedAnswers = useMemo(() => new Set(answers.filter(Boolean)), [answers]);
   void usedAnswers;
 
-  // Lazily compute move/ability lists (only populated once data is loaded)
+  // Lazily compute move/ability/pokemon lists (only populated once data is loaded)
   const allMoveNames = useMemo(() => getAllMoveNames(), []);
   const allAbilityNames = useMemo(() => getAllAbilityNames(), []);
+  const allPokemonNames = useMemo(() => getAllPokemonNames(), []);
+
+  const filteredWeightPokemon = weightPokemonSearch.length >= 2
+    ? allPokemonNames.filter(n => n.toLowerCase().includes(weightPokemonSearch.toLowerCase())).slice(0, 30)
+    : [];
+  const filteredHeightPokemon = heightPokemonSearch.length >= 2
+    ? allPokemonNames.filter(n => n.toLowerCase().includes(heightPokemonSearch.toLowerCase())).slice(0, 30)
+    : [];
 
   function getCategoryLabel(id: string | null): string {
     if (!id) return "";
@@ -161,8 +174,6 @@ export default function CreatePage() {
     status: "Status",
     weakness: "Weak to",
     resistance: "Resists",
-    weight: "Weight",
-    height: "Height",
   };
 
   // Determine if the current slot's category is a move or ability
@@ -410,6 +421,114 @@ export default function CreatePage() {
                   </div>
                 </>
               )}
+            </div>
+
+            {/* Heavier / Lighter than — searchable by pokemon */}
+            <div style={{ marginBottom: "16px" }}>
+              <h4 style={{ fontSize: "0.9rem", fontWeight: 600, marginBottom: "8px", color: "var(--text-secondary)" }}>
+                Heavier / Lighter than…
+              </h4>
+              <input
+                type="text"
+                placeholder="Search Pokémon… (e.g. snorlax, rattata)"
+                value={weightPokemonSearch}
+                onChange={e => setWeightPokemonSearch(e.target.value)}
+                style={{
+                  width: "100%", padding: "8px 10px", borderRadius: "6px",
+                  border: "1px solid var(--border)", background: "var(--bg-secondary)",
+                  color: "var(--text-primary)", fontSize: "0.9rem", marginBottom: "8px",
+                  boxSizing: "border-box",
+                }}
+                autoFocus={false}
+              />
+              {weightPokemonSearch.length < 2 && (
+                <p style={{ fontSize: "0.75rem", color: "var(--text-secondary)", margin: 0 }}>
+                  Type at least 2 characters to search.
+                </p>
+              )}
+              {weightPokemonSearch.length >= 2 && filteredWeightPokemon.length === 0 && (
+                <p style={{ fontSize: "0.75rem", color: "var(--text-secondary)", margin: 0 }}>
+                  No Pokémon found.
+                </p>
+              )}
+              <div style={{ display: "flex", flexWrap: "wrap", gap: "8px", marginTop: "4px" }}>
+                {filteredWeightPokemon.map(pokemonName => {
+                  const slug = pokemonName.toLowerCase();
+                  const gtId = `weight-gt-${slug}`;
+                  const ltId = `weight-lt-${slug}`;
+                  return (
+                    <div key={pokemonName} style={{ display: "flex", gap: "4px" }}>
+                      {[gtId, ltId].map(catId => {
+                        const isUsed = selectedIds.has(catId);
+                        const isCurrent = currentCatId === catId;
+                        return (
+                          <span
+                            key={catId}
+                            className={`category-chip ${isCurrent ? "selected" : ""} ${isUsed && !isCurrent ? "disabled" : ""}`}
+                            onClick={() => !isUsed || isCurrent ? selectCategory(catId) : undefined}
+                          >
+                            {getLabelForCategoryId(catId)}
+                          </span>
+                        );
+                      })}
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+
+            {/* Taller / Shorter than — searchable by pokemon */}
+            <div style={{ marginBottom: "16px" }}>
+              <h4 style={{ fontSize: "0.9rem", fontWeight: 600, marginBottom: "8px", color: "var(--text-secondary)" }}>
+                Taller / Shorter than…
+              </h4>
+              <input
+                type="text"
+                placeholder="Search Pokémon… (e.g. wailord, joltik)"
+                value={heightPokemonSearch}
+                onChange={e => setHeightPokemonSearch(e.target.value)}
+                style={{
+                  width: "100%", padding: "8px 10px", borderRadius: "6px",
+                  border: "1px solid var(--border)", background: "var(--bg-secondary)",
+                  color: "var(--text-primary)", fontSize: "0.9rem", marginBottom: "8px",
+                  boxSizing: "border-box",
+                }}
+                autoFocus={false}
+              />
+              {heightPokemonSearch.length < 2 && (
+                <p style={{ fontSize: "0.75rem", color: "var(--text-secondary)", margin: 0 }}>
+                  Type at least 2 characters to search.
+                </p>
+              )}
+              {heightPokemonSearch.length >= 2 && filteredHeightPokemon.length === 0 && (
+                <p style={{ fontSize: "0.75rem", color: "var(--text-secondary)", margin: 0 }}>
+                  No Pokémon found.
+                </p>
+              )}
+              <div style={{ display: "flex", flexWrap: "wrap", gap: "8px", marginTop: "4px" }}>
+                {filteredHeightPokemon.map(pokemonName => {
+                  const slug = pokemonName.toLowerCase();
+                  const gtId = `height-gt-${slug}`;
+                  const ltId = `height-lt-${slug}`;
+                  return (
+                    <div key={pokemonName} style={{ display: "flex", gap: "4px" }}>
+                      {[gtId, ltId].map(catId => {
+                        const isUsed = selectedIds.has(catId);
+                        const isCurrent = currentCatId === catId;
+                        return (
+                          <span
+                            key={catId}
+                            className={`category-chip ${isCurrent ? "selected" : ""} ${isUsed && !isCurrent ? "disabled" : ""}`}
+                            onClick={() => !isUsed || isCurrent ? selectCategory(catId) : undefined}
+                          >
+                            {getLabelForCategoryId(catId)}
+                          </span>
+                        );
+                      })}
+                    </div>
+                  );
+                })}
+              </div>
             </div>
 
             <button className="btn btn-secondary" style={{ marginTop: "8px" }} onClick={() => setPickingSlot(null)}>

--- a/src/data/pokemon.ts
+++ b/src/data/pokemon.ts
@@ -128,23 +128,7 @@ export const CATEGORIES: Category[] = [
   { id: "resists-fairy", label: "Resists Fairy", type: "resistance" },
   { id: "resists-normal", label: "Resists Normal", type: "resistance" },
 
-  // Weight — heavier than threshold
-  { id: "weight-gt-100", label: "Heavier than 10 kg", type: "weight" },
-  { id: "weight-gt-500", label: "Heavier than 50 kg", type: "weight" },
-  { id: "weight-gt-1000", label: "Heavier than 100 kg", type: "weight" },
-  { id: "weight-gt-2000", label: "Heavier than 200 kg", type: "weight" },
-  // Weight — lighter than threshold
-  { id: "weight-lt-10", label: "Lighter than 1 kg", type: "weight" },
-  { id: "weight-lt-50", label: "Lighter than 5 kg", type: "weight" },
-  { id: "weight-lt-100", label: "Lighter than 10 kg", type: "weight" },
-
-  // Height — taller than threshold
-  { id: "height-gt-10", label: "Taller than 1 m", type: "height" },
-  { id: "height-gt-20", label: "Taller than 2 m", type: "height" },
-  { id: "height-gt-30", label: "Taller than 3 m", type: "height" },
-  // Height — shorter than threshold
-  { id: "height-lt-5", label: "Shorter than 0.5 m", type: "height" },
-  { id: "height-lt-10", label: "Shorter than 1 m", type: "height" },
+  // Weight and Height categories are dynamic (pokemon-relative) — see getLabelForCategoryId / pokemonMatchesCategory
 ];
 
 // --- New categories: weakness, resistance, weight, height ---
@@ -232,21 +216,28 @@ export function pokemonMatchesCategory(pokemon: Pokemon, categoryId: string): bo
       return calcTypeEffectiveness(value, pokemon.types) < 1;
     case "weight": {
       if (pokemon.weight === undefined) return false;
-      // value is like "gt-100" or "lt-50"
+      // value is like "gt-snorlax" or "lt-rattata"
       const sepIdx = value.indexOf("-");
+      if (sepIdx === -1) return false;
       const dir = value.substring(0, sepIdx);
-      const threshold = parseInt(value.substring(sepIdx + 1));
-      if (dir === "gt") return pokemon.weight > threshold;
-      if (dir === "lt") return pokemon.weight < threshold;
+      const refName = value.substring(sepIdx + 1);
+      const ref = POKEMON.find(p => p.name.toLowerCase() === refName.toLowerCase());
+      if (!ref || ref.weight === undefined) return false;
+      if (dir === "gt") return pokemon.weight > ref.weight;
+      if (dir === "lt") return pokemon.weight < ref.weight;
       return false;
     }
     case "height": {
       if (pokemon.height === undefined) return false;
+      // value is like "gt-wailord" or "lt-joltik"
       const sepIdx = value.indexOf("-");
+      if (sepIdx === -1) return false;
       const dir = value.substring(0, sepIdx);
-      const threshold = parseInt(value.substring(sepIdx + 1));
-      if (dir === "gt") return pokemon.height > threshold;
-      if (dir === "lt") return pokemon.height < threshold;
+      const refName = value.substring(sepIdx + 1);
+      const ref = POKEMON.find(p => p.name.toLowerCase() === refName.toLowerCase());
+      if (!ref || ref.height === undefined) return false;
+      if (dir === "gt") return pokemon.height > ref.height;
+      if (dir === "lt") return pokemon.height < ref.height;
       return false;
     }
     case "move":
@@ -266,6 +257,21 @@ export function getLabelForCategoryId(id: string): string {
   if (dashIdx === -1) return id;
   const group = id.substring(0, dashIdx);
   const value = id.substring(dashIdx + 1);
+  if (group === "weight" || group === "height") {
+    const sepIdx = value.indexOf("-");
+    if (sepIdx !== -1) {
+      const dir = value.substring(0, sepIdx);
+      const refName = value.substring(sepIdx + 1);
+      const displayName = refName.split("-").map(w => w.charAt(0).toUpperCase() + w.slice(1)).join(" ");
+      if (group === "weight") {
+        if (dir === "gt") return `Heavier than ${displayName}`;
+        if (dir === "lt") return `Lighter than ${displayName}`;
+      } else {
+        if (dir === "gt") return `Taller than ${displayName}`;
+        if (dir === "lt") return `Shorter than ${displayName}`;
+      }
+    }
+  }
   const formatted = value.split("-").map(w => w.charAt(0).toUpperCase() + w.slice(1)).join(" ");
   if (group === "move") return `Can learn ${formatted}`;
   if (group === "ability") return `Has ability ${formatted}`;
@@ -281,6 +287,14 @@ export function isValidCategoryId(id: string): boolean {
   const value = id.substring(dashIdx + 1);
   if (group === "move") return getAllMoveNames().includes(value);
   if (group === "ability") return getAllAbilityNames().includes(value);
+  if (group === "weight" || group === "height") {
+    const sepIdx = value.indexOf("-");
+    if (sepIdx === -1) return false;
+    const dir = value.substring(0, sepIdx);
+    if (dir !== "gt" && dir !== "lt") return false;
+    const refName = value.substring(sepIdx + 1);
+    return POKEMON.some(p => p.name.toLowerCase() === refName.toLowerCase());
+  }
   return false;
 }
 


### PR DESCRIPTION
Weight and height categories now compare against a specific Pokémon's
stats rather than a hardcoded number. Category IDs use the format
`weight-gt-snorlax` / `height-lt-joltik`, and labels read
"Heavier than Snorlax" / "Shorter than Joltik". The create page
gains searchable Heavier/Lighter and Taller/Shorter sections to
pick the reference Pokémon.

https://claude.ai/code/session_01V1GZfbDRb4GRNGTJezxfMC