### PR TITLE
Fix mobile login error by adding trustHost and proper 401 handling

### DIFF
--- a/src/app/create/page.tsx
+++ b/src/app/create/page.tsx
@@ -139,6 +139,8 @@ export default function CreatePage() {
     });
     if (res.ok) {
       router.push("/manage");
+    } else if (res.status === 401) {
+      window.location.href = "/api/auth/signin";
     } else {
       const data = await res.json();
       setError(data.error || "Failed to submit");

--- a/src/app/manage/page.tsx
+++ b/src/app/manage/page.tsx
@@ -20,8 +20,15 @@ export default function ManagePage() {
 
   function fetchGrids() {
     fetch("/api/grids")
-      .then(r => r.json())
+      .then(r => {
+        if (r.status === 401) {
+          window.location.href = "/api/auth/signin";
+          return null;
+        }
+        return r.json();
+      })
       .then(data => {
+        if (!data) return;
         if (Array.isArray(data)) setGrids(data);
         else setError(data.error || "Failed to load");
       })

--- a/src/app/play/all/page.tsx
+++ b/src/app/play/all/page.tsx
@@ -27,8 +27,15 @@ export default function PlayAllPage() {
     setAnswers(Array(9).fill(""));
     setError("");
     fetch("/api/play/all")
-      .then(r => r.json())
+      .then(r => {
+        if (r.status === 401) {
+          window.location.href = "/api/auth/signin";
+          return null;
+        }
+        return r.json();
+      })
       .then(data => {
+        if (!data) return;
         if (data.grid) {
           setGrid(data.grid);
           setNoMore(false);

--- a/src/app/play/guess-chat/page.tsx
+++ b/src/app/play/guess-chat/page.tsx
@@ -55,8 +55,15 @@ export default function GuessChatPage() {
   const fetchSession = useCallback(() => {
     setLoading(true);
     fetch("/api/play/guess-chat")
-      .then(r => r.json())
+      .then(r => {
+        if (r.status === 401) {
+          window.location.href = "/api/auth/signin";
+          return null;
+        }
+        return r.json();
+      })
       .then(data => {
+        if (!data) return;
         if (data.session) {
           setSession(data.session);
           setEntries(data.entries || []);

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -19,8 +19,15 @@ export default function SettingsPage() {
 
   useEffect(() => {
     fetch("/api/users/me")
-      .then(r => r.json())
+      .then(r => {
+        if (r.status === 401) {
+          setUser(null);
+          return null;
+        }
+        return r.json();
+      })
       .then(data => {
+        if (!data) return;
         if (data.error) setError(data.error);
         else {
           setUser(data);

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -3,6 +3,7 @@ import Discord from "next-auth/providers/discord";
 import { getDb } from "./db";
 
 export const { handlers, signIn, signOut, auth } = NextAuth({
+  trustHost: true,
   providers: [
     Discord({
       clientId: process.env.DISCORD_CLIENT_ID!,


### PR DESCRIPTION
NextAuth v5 rejects OAuth callbacks when the host isn't explicitly
trusted, causing login failures on mobile devices accessing the deployed
URL. Added trustHost: true to the NextAuth config. Also added 401
response handling across all protected client pages so unauthenticated
users get redirected to sign in instead of seeing generic error messages.

https://claude.ai/code/session_01Hq9sE7xRXipWhy3fLiPC8k