### PR TITLE
feat: add optional fetch-pokemon step to deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,13 @@ name: Deploy to Vercel
 on:
   push:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      update_pokemon_data:
+        description: 'Fetch latest Pokémon data from PokéAPI before deploying'
+        required: false
+        default: false
+        type: boolean
 
 env:
   VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
@@ -18,6 +25,21 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
+
+      - name: Fetch Pokémon data
+        if: ${{ inputs.update_pokemon_data }}
+        run: |
+          npm ci
+          npm run fetch-pokemon
+
+      - name: Commit updated Pokémon data
+        if: ${{ inputs.update_pokemon_data }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add src/data/pokemon-data.json
+          git diff --staged --quiet || git commit -m "chore: update pokemon-data.json from PokéAPI"
+          git push
 
       - name: Install Vercel CLI
         run: npm install -g vercel


### PR DESCRIPTION
Adds a workflow_dispatch trigger with an update_pokemon_data boolean input.
When enabled, runs npm run fetch-pokemon before building and commits the
updated pokemon-data.json back to the repo so future deploys use it.

https://claude.ai/code/session_01XnPmzgFDJTzCH2kc8rs8Bo