### PR TITLE
fix: forward x-forwarded-host in mobile auth internal fetch

### DIFF
--- a/src/app/api/auth/discord-mobile/route.ts
+++ b/src/app/api/auth/discord-mobile/route.ts
@@ -21,6 +21,12 @@ export async function GET(request: NextRequest) {
       headers: {
         cookie: request.headers.get("cookie") || "",
         host: request.headers.get("host") || "",
+        // x-forwarded-host carries the real public hostname on Vercel/proxies;
+        // NextAuth v5 needs it to build the correct OAuth callback URL.
+        "x-forwarded-host":
+          request.headers.get("x-forwarded-host") ||
+          request.headers.get("host") ||
+          "",
         // Use a non-mobile UA so this internal call isn't intercepted again
         "user-agent": "internal",
         "x-forwarded-proto": request.headers.get("x-forwarded-proto") || "https",


### PR DESCRIPTION
NextAuth v5 on Vercel uses the x-forwarded-host header to determine
the public hostname when constructing OAuth callback URLs. The internal
server-side fetch in the discord-mobile route was missing this header,
so NextAuth fell back to an internal Vercel hostname, causing it to
fail to build a valid redirect URI and show the "server configuration"
error on mobile sign-in.

https://claude.ai/code/session_01NdCWD2v6NrZ9rQJQqrP7JX