### PR TITLE
Update Discord mobile auth to support Auth.js v5 POST requirement

### DIFF
--- a/src/app/api/auth/discord-mobile/route.ts
+++ b/src/app/api/auth/discord-mobile/route.ts
@@ -5,12 +5,13 @@ export async function GET(request: NextRequest) {
   const isMobile = /iPhone|iPad|iPod|Android/i.test(userAgent);
 
   if (!isMobile) {
-    return NextResponse.redirect(new URL("/api/auth/signin/discord", request.url));
+    return NextResponse.redirect(new URL("/api/auth/signin", request.url));
   }
 
   // Make an internal request to NextAuth's Discord signin endpoint so it
   // generates a state token and sets the state cookie, then capture the
   // resulting Discord OAuth URL so we can swap the scheme to discord://.
+  // Auth.js v5 requires POST to initiate OAuth (GET is no longer supported).
   const signinUrl = new URL("/api/auth/signin/discord", request.url);
 
   let discordOAuthUrl: string | null = null;
@@ -18,7 +19,9 @@ export async function GET(request: NextRequest) {
 
   try {
     const response = await fetch(signinUrl.toString(), {
+      method: "POST",
       headers: {
+        "content-type": "application/x-www-form-urlencoded",
         cookie: request.headers.get("cookie") || "",
         host: request.headers.get("host") || "",
         // x-forwarded-host carries the real public hostname on Vercel/proxies;
@@ -44,11 +47,11 @@ export async function GET(request: NextRequest) {
       if (raw) stateCookies = [raw];
     }
   } catch {
-    return NextResponse.redirect(new URL("/api/auth/signin/discord", request.url));
+    return NextResponse.redirect(new URL("/api/auth/signin", request.url));
   }
 
   if (!discordOAuthUrl || !discordOAuthUrl.includes("discord.com/oauth2/authorize")) {
-    return NextResponse.redirect(new URL("/api/auth/signin/discord", request.url));
+    return NextResponse.redirect(new URL("/api/auth/signin", request.url));
   }
 
   // Replace the https scheme with the Discord app deep-link scheme


### PR DESCRIPTION
## Summary
Updated the Discord mobile authentication endpoint to be compatible with Auth.js v5, which requires POST requests instead of GET requests to initiate OAuth flows.

## Key Changes
- Changed internal fetch request from GET to POST when calling the Discord signin endpoint
- Added required `content-type: application/x-www-form-urlencoded` header for POST request
- Updated fallback redirect URLs from `/api/auth/signin/discord` to `/api/auth/signin` for consistency across error cases
- Added clarifying comment explaining the Auth.js v5 POST requirement

## Implementation Details
The changes ensure that the mobile Discord authentication flow properly initiates OAuth by making a POST request to the signin endpoint, which is now required by Auth.js v5. The fallback redirects were also standardized to use the generic signin route instead of the provider-specific endpoint, providing a more consistent user experience when errors occur.

https://claude.ai/code/session_01RpZCkKzh1cL5LU6z9vTboH