### PR TITLE
Make getDb() async to ensure database initialization completes

### DIFF
--- a/src/app/api/admin/grids/[id]/route.ts
+++ b/src/app/api/admin/grids/[id]/route.ts
@@ -13,7 +13,7 @@ export async function PATCH(
   }
 
   const { id } = await params;
-  const db = getDb();
+  const db = await getDb();
 
   const gridResult = await db.execute({
     sql: "SELECT * FROM grids WHERE id = ?",
@@ -62,7 +62,7 @@ export async function DELETE(
   }
 
   const { id } = await params;
-  const db = getDb();
+  const db = await getDb();
   await db.execute({ sql: "DELETE FROM grids WHERE id = ?", args: [id] });
   return NextResponse.json({ ok: true });
 }

--- a/src/app/api/admin/grids/route.ts
+++ b/src/app/api/admin/grids/route.ts
@@ -9,7 +9,7 @@ export async function GET() {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 
-  const db = getDb();
+  const db = await getDb();
   const result = await db.execute(
     `SELECT g.*, u.display_name as creator_name, u.discord_username
     FROM grids g

--- a/src/app/api/grids/[id]/route.ts
+++ b/src/app/api/grids/[id]/route.ts
@@ -14,7 +14,7 @@ export async function GET(
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const db = getDb();
+  const db = await getDb();
   const result = await db.execute({
     sql: "SELECT * FROM grids WHERE id = ?",
     args: [id],
@@ -37,7 +37,7 @@ export async function PATCH(
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const db = getDb();
+  const db = await getDb();
   const gridResult = await db.execute({
     sql: "SELECT * FROM grids WHERE id = ?",
     args: [id],
@@ -125,7 +125,7 @@ export async function DELETE(
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const db = getDb();
+  const db = await getDb();
   const gridResult = await db.execute({
     sql: "SELECT * FROM grids WHERE id = ?",
     args: [id],

--- a/src/app/api/grids/[id]/solve/route.ts
+++ b/src/app/api/grids/[id]/solve/route.ts
@@ -15,7 +15,7 @@ export async function POST(
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const db = getDb();
+  const db = await getDb();
   const gridResult = await db.execute({
     sql: "SELECT * FROM grids WHERE id = ?",
     args: [gridId],

--- a/src/app/api/grids/route.ts
+++ b/src/app/api/grids/route.ts
@@ -11,7 +11,7 @@ export async function GET() {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const db = getDb();
+  const db = await getDb();
   const result = await db.execute({
     sql: "SELECT * FROM grids WHERE created_by = ? ORDER BY created_at DESC",
     args: [session.user.id],
@@ -75,7 +75,7 @@ export async function POST(req: NextRequest) {
   }
 
   const id = generateId();
-  const db = getDb();
+  const db = await getDb();
   await db.execute({
     sql: "INSERT INTO grids (id, created_by, row_categories, col_categories, example_answers) VALUES (?, ?, ?, ?, ?)",
     args: [id, session.user.id, JSON.stringify(rowCategories), JSON.stringify(colCategories), JSON.stringify(exampleAnswers)],

--- a/src/app/api/play/all/route.ts
+++ b/src/app/api/play/all/route.ts
@@ -13,7 +13,7 @@ export async function GET(req: NextRequest) {
   const { searchParams } = new URL(req.url);
   const replay = searchParams.get("replay") === "true";
 
-  const db = getDb();
+  const db = await getDb();
 
   if (replay) {
     // Get a random grid the user HAS already played, excluding their own and submissions

--- a/src/app/api/play/guess-chat/[id]/route.ts
+++ b/src/app/api/play/guess-chat/[id]/route.ts
@@ -13,7 +13,7 @@ export async function PATCH(
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const db = getDb();
+  const db = await getDb();
   const guessSessionResult = await db.execute({
     sql: "SELECT * FROM guess_sessions WHERE id = ? AND player_id = ?",
     args: [sessionId, session.user.id],
@@ -68,7 +68,7 @@ export async function GET(
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const db = getDb();
+  const db = await getDb();
   const guessSessionResult = await db.execute({
     sql: "SELECT * FROM guess_sessions WHERE id = ? AND player_id = ?",
     args: [sessionId, session.user.id],

--- a/src/app/api/play/guess-chat/route.ts
+++ b/src/app/api/play/guess-chat/route.ts
@@ -11,7 +11,7 @@ export async function GET() {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const db = getDb();
+  const db = await getDb();
 
   // Find existing in-progress session
   let guessSessionResult = await db.execute({
@@ -89,7 +89,7 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const db = getDb();
+  const db = await getDb();
 
   const guessSessionResult = await db.execute({
     sql: "SELECT * FROM guess_sessions WHERE player_id = ? AND status = 'in_progress' ORDER BY created_at DESC LIMIT 1",

--- a/src/app/api/users/me/route.ts
+++ b/src/app/api/users/me/route.ts
@@ -9,7 +9,7 @@ export async function GET() {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const db = getDb();
+  const db = await getDb();
   const result = await db.execute({
     sql: "SELECT * FROM users WHERE id = ?",
     args: [session.user.id],
@@ -36,7 +36,7 @@ export async function PATCH(req: NextRequest) {
     return NextResponse.json({ error: "Display name must be 32 characters or less" }, { status: 400 });
   }
 
-  const db = getDb();
+  const db = await getDb();
   await db.execute({
     sql: "UPDATE users SET display_name = ?, updated_at = datetime('now') WHERE id = ?",
     args: [displayName.trim(), session.user.id],

--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -9,7 +9,7 @@ export async function GET() {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const db = getDb();
+  const db = await getDb();
   const result = await db.execute(
     "SELECT id, display_name, avatar_url FROM users ORDER BY display_name"
   );

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -22,7 +22,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
         token.username = profile.username;
         token.avatar = profile.avatar;
 
-        const db = getDb();
+        const db = await getDb();
         const avatarUrl = profile.avatar
           ? `https://cdn.discordapp.com/avatars/${profile.id}/${profile.avatar}.png`
           : null;

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,15 +1,18 @@
 import { createClient, type Client } from "@libsql/client";
 
 let db: Client;
+let initPromise: Promise<void> | null = null;
 
-export function getDb(): Client {
+export async function getDb(): Promise<Client> {
   if (!db) {
     db = createClient({
       url: process.env.TURSO_DATABASE_URL || "file:local.db",
       authToken: process.env.TURSO_AUTH_TOKEN,
     });
-    // Initialize tables on first use
-    initializeDb(db);
+    initPromise = initializeDb(db);
+  }
+  if (initPromise) {
+    await initPromise;
   }
   return db;
 }


### PR DESCRIPTION
## Summary
Convert the `getDb()` function from synchronous to asynchronous to properly handle database initialization. This ensures that table initialization completes before the database client is used, preventing potential race conditions.

## Key Changes
- Modified `getDb()` in `src/lib/db.ts` to return `Promise<Client>` instead of `Client`
- Added `initPromise` state variable to track the initialization promise and ensure it only runs once
- Updated all `getDb()` call sites across the codebase to use `await getDb()`:
  - API routes for grids (GET, POST, PATCH, DELETE operations)
  - Admin grid management routes
  - Play/guess-chat routes
  - User profile routes
  - Authentication initialization in `src/lib/auth.ts`

## Implementation Details
- The initialization promise is stored and reused on subsequent calls to prevent multiple concurrent initialization attempts
- All callers properly await the async function, ensuring database readiness before executing queries
- This change maintains backward compatibility at the API level while fixing the underlying initialization race condition

https://claude.ai/code/session_01WYLm2Qqh9Fd1KtXHxnwN9F