### PR TITLE
Fix login status not reflected in UI after sign-in

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,9 @@
-export default function Home() {
+import { auth } from "@/lib/auth";
+
+export default async function Home() {
+  const session = await auth();
+  const isLoggedIn = !!session?.user?.id;
+
   return (
     <div style={{ textAlign: "center", paddingTop: "40px" }}>
       <h1 style={{ fontSize: "clamp(2rem, 8vw, 3rem)", fontWeight: 800, marginBottom: "16px" }}>
@@ -43,15 +48,17 @@ export default function Home() {
         </a>
       </div>
 
-      <div style={{ marginTop: "40px" }}>
-        <a
-          href="/api/auth/discord-mobile"
-          className="btn btn-primary"
-          style={{ padding: "14px 32px", fontSize: "1.05rem", borderRadius: "10px" }}
-        >
-          Sign in with Discord
-        </a>
-      </div>
+      {!isLoggedIn && (
+        <div style={{ marginTop: "40px" }}>
+          <a
+            href="/api/auth/discord-mobile"
+            className="btn btn-primary"
+            style={{ padding: "14px 32px", fontSize: "1.05rem", borderRadius: "10px" }}
+          >
+            Sign in with Discord
+          </a>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -10,16 +10,29 @@ const links = [
   { href: "/settings", label: "Settings" },
 ];
 
+interface NavUser {
+  discord_username: string;
+  avatar_url: string | null;
+}
+
 export default function Nav() {
   const pathname = usePathname();
   const [isAdmin, setIsAdmin] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
+  const [user, setUser] = useState<NavUser | null | undefined>(undefined);
 
   useEffect(() => {
     fetch("/api/admin/check")
       .then(r => r.json())
       .then(data => setIsAdmin(data.isAdmin === true))
       .catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    fetch("/api/users/me")
+      .then(r => r.status === 401 ? null : r.json())
+      .then(data => setUser(data && !data.error ? data : null))
+      .catch(() => setUser(null));
   }, []);
 
   // Close menu on route change
@@ -96,6 +109,30 @@ export default function Nav() {
             style={{ padding: "6px 14px", fontSize: "0.85rem", borderColor: "var(--accent)" }}
           >
             Admin
+          </a>
+        )}
+        {user === null && (
+          <a
+            href="/api/auth/discord-mobile"
+            className="btn btn-primary"
+            style={{ padding: "6px 14px", fontSize: "0.85rem" }}
+          >
+            Sign In
+          </a>
+        )}
+        {user && (
+          <a
+            href="/settings"
+            style={{ display: "flex", alignItems: "center", gap: "8px", textDecoration: "none", color: "inherit" }}
+          >
+            {user.avatar_url && (
+              <img
+                src={user.avatar_url}
+                alt=""
+                style={{ width: 28, height: 28, borderRadius: "50%", border: "2px solid var(--border)" }}
+              />
+            )}
+            <span style={{ fontSize: "0.85rem", fontWeight: 600 }}>{user.discord_username}</span>
           </a>
         )}
       </div>


### PR DESCRIPTION
- Home page (page.tsx): check auth server-side and hide "Sign in with
  Discord" button when the user is already logged in
- Nav (Nav.tsx): fetch /api/users/me on mount and show the user's
  Discord avatar + username when logged in, or a "Sign In" button when
  not — giving persistent visual confirmation of auth state on every page

https://claude.ai/code/session_01LYk5RZYwm3EFw9gMNK4mjQ