### PR TITLE
Fix Pokémon sprite fallbacks and improve guess grid filtering

### DIFF
--- a/src/app/api/play/guess-chat/route.ts
+++ b/src/app/api/play/guess-chat/route.ts
@@ -67,9 +67,9 @@ export async function GET() {
   // Find next unplayed grid
   const nextGrid = submissionGridsResult.rows.find(g => !completedGridIds.has(g.id as string));
 
-  // Get all users for the guess dropdown
+  // Get only users who have a submission grid (valid guess options)
   const usersResult = await db.execute(
-    "SELECT id, display_name, avatar_url FROM users ORDER BY display_name"
+    "SELECT u.id, u.display_name, u.avatar_url FROM users u WHERE EXISTS (SELECT 1 FROM grids g WHERE g.created_by = u.id AND g.is_submission = 1) ORDER BY u.display_name"
   );
 
   return NextResponse.json({

--- a/src/components/PokemonAutocomplete.tsx
+++ b/src/components/PokemonAutocomplete.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useRef, useEffect, useMemo } from "react";
-import { getAllPokemonNames, getPokemonSpriteUrl } from "@/data/pokemon";
+import { getAllPokemonNames, getPokemonSpriteUrl, SUBSTITUTE_SPRITE_URL } from "@/data/pokemon";
 
 interface Props {
   value: string;
@@ -78,6 +78,7 @@ export default function PokemonAutocomplete({ value, onChange, placeholder, filt
             src={spriteUrl}
             alt={value}
             style={{ width: "40px", height: "40px", imageRendering: "pixelated" }}
+            onError={e => { (e.currentTarget as HTMLImageElement).src = SUBSTITUTE_SPRITE_URL; }}
           />
         </div>
       )}
@@ -104,9 +105,10 @@ export default function PokemonAutocomplete({ value, onChange, placeholder, filt
               style={{ display: "flex", alignItems: "center" }}
             >
               <img
-                src={getPokemonSpriteUrl(name) || ""}
+                src={getPokemonSpriteUrl(name) || SUBSTITUTE_SPRITE_URL}
                 alt=""
                 style={{ width: "24px", height: "24px", marginRight: "8px", imageRendering: "pixelated" }}
+                onError={e => { (e.currentTarget as HTMLImageElement).src = SUBSTITUTE_SPRITE_URL; }}
               />
               {name}
             </div>

--- a/src/data/pokemon.ts
+++ b/src/data/pokemon.ts
@@ -192,6 +192,10 @@ export function pokemonMatchesCategory(pokemon: Pokemon, categoryId: string): bo
       );
     }
     case "evo":
+      if (value === "has-mega") {
+        // Mega forms themselves have "has-mega" in evolutionMethod but should only match "is-mega"
+        return pokemon.evolutionMethod.includes("has-mega") && !pokemon.status.includes("is-mega");
+      }
       return pokemon.evolutionMethod.includes(value);
     case "status":
       return pokemon.status.includes(value);
@@ -341,6 +345,9 @@ export function getFilteredPokemonNames(rowCategoryId?: string, colCategoryId?: 
   }
   return names;
 }
+
+export const SUBSTITUTE_SPRITE_URL =
+  "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/substitute.png";
 
 // Get sprite URL for a Pokémon (uses PokéAPI sprites)
 export function getPokemonSpriteUrl(name: string): string | null {


### PR DESCRIPTION
## Summary
This PR improves the robustness of Pokémon sprite handling and refines the guess grid feature by filtering users to only those with valid submission grids.

## Key Changes

- **Pokémon Sprite Fallback**: Added a `SUBSTITUTE_SPRITE_URL` constant pointing to the Pokémon Substitute sprite as a fallback image. Updated `PokemonAutocomplete` component to use this fallback when sprite URLs fail to load, both in the selected value display and in the dropdown list items.

- **Evolution Category Filter**: Fixed the "has-mega" evolution category filter to correctly exclude Pokémon that are themselves Mega forms. Mega forms have "has-mega" in their evolution method but should only match the "is-mega" status filter, not the "evo" category filter.

- **Guess Grid User Filtering**: Modified the API endpoint to only retrieve users who have created submission grids, rather than all users. This ensures the guess dropdown only shows valid guess options and improves query efficiency.

## Implementation Details

- The substitute sprite fallback is applied via `onError` handlers on image elements, gracefully handling missing or broken sprite URLs
- The evolution filter logic now checks both the evolution method and status to properly distinguish between Pokémon with Mega forms and Pokémon that are Mega forms themselves
- The user query now uses an EXISTS subquery to filter for users with submission grids, maintaining alphabetical ordering

https://claude.ai/code/session_01PGNBxXaiyY7xidP3RUprTb