### PR TITLE
Add custom category that accepts any Pokémon

### DIFF
--- a/src/app/create/page.tsx
+++ b/src/app/create/page.tsx
@@ -169,6 +169,7 @@ export default function CreatePage() {
   }, {} as Record<string, typeof CATEGORIES>);
 
   const groupLabels: Record<string, string> = {
+    custom: "Special",
     type: "Types",
     generation: "Generations",
     egg_group: "Egg Groups",

--- a/src/app/create/page.tsx
+++ b/src/app/create/page.tsx
@@ -31,6 +31,7 @@ export default function CreatePage() {
   const [abilitySearch, setAbilitySearch] = useState("");
   const [weightPokemonSearch, setWeightPokemonSearch] = useState("");
   const [heightPokemonSearch, setHeightPokemonSearch] = useState("");
+  const [customLabelInput, setCustomLabelInput] = useState("");
 
   // Reset search inputs when opening a new picker slot
   useEffect(() => {
@@ -39,6 +40,10 @@ export default function CreatePage() {
       setAbilitySearch("");
       setWeightPokemonSearch("");
       setHeightPokemonSearch("");
+      const currentId = pickingSlot.axis === "row"
+        ? rowCategories[pickingSlot.index]
+        : colCategories[pickingSlot.index];
+      setCustomLabelInput(currentId?.startsWith("custom-") ? currentId.substring(7) : "");
     }
   }, [pickingSlot?.axis, pickingSlot?.index]); // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -169,7 +174,6 @@ export default function CreatePage() {
   }, {} as Record<string, typeof CATEGORIES>);
 
   const groupLabels: Record<string, string> = {
-    custom: "Special",
     type: "Types",
     generation: "Generations",
     egg_group: "Egg Groups",
@@ -317,6 +321,42 @@ export default function CreatePage() {
                 </div>
               </div>
             ))}
+
+            {/* Custom — any Pokémon, user-defined label */}
+            <div style={{ marginBottom: "16px" }}>
+              <h4 style={{ fontSize: "0.9rem", fontWeight: 600, marginBottom: "8px", color: "var(--text-secondary)" }}>
+                Custom (Any Pokémon)
+              </h4>
+              <p style={{ fontSize: "0.8rem", color: "var(--text-secondary)", marginBottom: "8px" }}>
+                Any Pokémon is valid for this column/row. Add a label to describe the category.
+              </p>
+              <div style={{ display: "flex", gap: "8px" }}>
+                <input
+                  type="text"
+                  placeholder="Label (e.g. Cute Pokémon)"
+                  value={customLabelInput}
+                  onChange={e => setCustomLabelInput(e.target.value)}
+                  onKeyDown={e => {
+                    if (e.key === "Enter" && customLabelInput.trim()) {
+                      selectCategory("custom-" + customLabelInput.trim());
+                    }
+                  }}
+                  style={{
+                    flex: 1, padding: "8px 10px", borderRadius: "6px",
+                    border: "1px solid var(--border)", background: "var(--bg-secondary)",
+                    color: "var(--text-primary)", fontSize: "0.9rem",
+                    boxSizing: "border-box",
+                  }}
+                />
+                <button
+                  className="btn btn-secondary"
+                  onClick={() => customLabelInput.trim() && selectCategory("custom-" + customLabelInput.trim())}
+                  disabled={!customLabelInput.trim()}
+                >
+                  Use
+                </button>
+              </div>
+            </div>
 
             {/* Can Learn Move — searchable */}
             <div style={{ marginBottom: "16px" }}>

--- a/src/data/pokemon.ts
+++ b/src/data/pokemon.ts
@@ -22,9 +22,6 @@ export const POKEMON: Pokemon[] = pokemonData;
 
 // Categories that can be used as row/column headers
 export const CATEGORIES: Category[] = [
-  // Custom (accepts any Pokémon)
-  { id: "custom", label: "Any Pokémon", type: "custom" },
-
   // Types
   { id: "type-normal", label: "Normal Type", type: "type" },
   { id: "type-fire", label: "Fire Type", type: "type" },
@@ -178,7 +175,7 @@ const EGG_GROUP_MAP: Record<string, string[]> = {
 
 // Check if a Pokémon matches a given category
 export function pokemonMatchesCategory(pokemon: Pokemon, categoryId: string): boolean {
-  if (categoryId === "custom") return true;
+  if (categoryId.startsWith("custom-")) return true;
   const dashIdx = categoryId.indexOf("-");
   if (dashIdx === -1) return false;
   const group = categoryId.substring(0, dashIdx);
@@ -265,6 +262,7 @@ export function getLabelForCategoryId(id: string): string {
       }
     }
   }
+  if (group === "custom") return value;
   const formatted = value.split("-").map(w => w.charAt(0).toUpperCase() + w.slice(1)).join(" ");
   if (group === "move") return `Can learn ${formatted}`;
   if (group === "ability") return `Has ability ${formatted}`;
@@ -278,6 +276,7 @@ export function isValidCategoryId(id: string): boolean {
   if (dashIdx === -1) return false;
   const group = id.substring(0, dashIdx);
   const value = id.substring(dashIdx + 1);
+  if (group === "custom") return value.trim().length > 0;
   if (group === "move") return getAllMoveNames().includes(value);
   if (group === "ability") return getAllAbilityNames().includes(value);
   if (group === "weight" || group === "height") {

--- a/src/data/pokemon.ts
+++ b/src/data/pokemon.ts
@@ -22,6 +22,9 @@ export const POKEMON: Pokemon[] = pokemonData;
 
 // Categories that can be used as row/column headers
 export const CATEGORIES: Category[] = [
+  // Custom (accepts any Pokémon)
+  { id: "custom", label: "Any Pokémon", type: "custom" },
+
   // Types
   { id: "type-normal", label: "Normal Type", type: "type" },
   { id: "type-fire", label: "Fire Type", type: "type" },
@@ -175,6 +178,7 @@ const EGG_GROUP_MAP: Record<string, string[]> = {
 
 // Check if a Pokémon matches a given category
 export function pokemonMatchesCategory(pokemon: Pokemon, categoryId: string): boolean {
+  if (categoryId === "custom") return true;
   const dashIdx = categoryId.indexOf("-");
   if (dashIdx === -1) return false;
   const group = categoryId.substring(0, dashIdx);

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -9,7 +9,8 @@ export type CategoryType =
   | "weight"
   | "height"
   | "move"
-  | "ability";
+  | "ability"
+  | "custom";
 
 export interface Category {
   id: string;


### PR DESCRIPTION
Adds a "Any Pokémon" custom category (id: "custom") which bypasses all
validation — any Pokémon is a valid answer for a row or column using it.

https://claude.ai/code/session_01K9iRjgmNyqUJ2b55AjWPz9