### PR TITLE
Allow players to guess their own submissions in Guess Chat

### DIFF
--- a/src/app/api/play/guess-chat/route.ts
+++ b/src/app/api/play/guess-chat/route.ts
@@ -19,25 +19,19 @@ export async function GET() {
     args: [session.user.id],
   });
 
-  // Get all submission grids (not the player's own)
+  // Get all submission grids (including the player's own)
   const submissionGridsResult = await db.execute({
     sql: `SELECT g.id, g.row_categories, g.col_categories, g.created_by
     FROM grids g
-    WHERE g.is_submission = 1 AND g.created_by != ?
+    WHERE g.is_submission = 1
     ORDER BY RANDOM()`,
-    args: [session.user.id],
+    args: [],
   });
 
   if (submissionGridsResult.rows.length === 0) {
-    // Check if the player themselves has a submission — helps surface a clearer message
-    const ownSubmissionResult = await db.execute({
-      sql: "SELECT id FROM grids WHERE created_by = ? AND is_submission = 1 LIMIT 1",
-      args: [session.user.id],
-    });
     return NextResponse.json({
       session: null,
       message: "No submissions available to play",
-      hasOwnSubmission: ownSubmissionResult.rows.length > 0,
     });
   }
 

--- a/src/app/play/guess-chat/page.tsx
+++ b/src/app/play/guess-chat/page.tsx
@@ -40,7 +40,6 @@ export default function GuessChatPage() {
   const [totalGrids, setTotalGrids] = useState(0);
   const [completedCount, setCompletedCount] = useState(0);
   const [users, setUsers] = useState<User[]>([]);
-  const [hasOwnSubmission, setHasOwnSubmission] = useState(false);
 
   const [answers, setAnswers] = useState<string[]>(Array(9).fill(""));
   const [guessedAuthorId, setGuessedAuthorId] = useState("");
@@ -71,7 +70,6 @@ export default function GuessChatPage() {
           setTotalGrids(data.totalGrids);
           setCompletedCount(data.completedCount);
           setUsers(data.users || []);
-          setHasOwnSubmission(false);
 
           // If session was already submitted, redirect to results
           if (data.session.status === "submitted") {
@@ -80,7 +78,6 @@ export default function GuessChatPage() {
           }
         } else {
           setSession(null);
-          setHasOwnSubmission(!!data.hasOwnSubmission);
         }
       })
       .catch(() => setError("Failed to load"))
@@ -165,13 +162,9 @@ export default function GuessChatPage() {
   if (!session) {
     return (
       <div style={{ textAlign: "center", paddingTop: "48px" }}>
-        <h2 style={{ fontWeight: 700, marginBottom: "12px" }}>
-          {hasOwnSubmission ? "Your grid is submitted!" : "No Submissions Yet"}
-        </h2>
+        <h2 style={{ fontWeight: 700, marginBottom: "12px" }}>No Submissions Yet</h2>
         <p style={{ color: "var(--text-secondary)", marginBottom: "24px" }}>
-          {hasOwnSubmission
-            ? "You can't play your own submission — waiting for other players to submit their grids."
-            : "Waiting for players to mark their grids as submissions."}
+          Waiting for players to mark their grids as submissions.
         </p>
         <a href="/play" className="btn btn-secondary">Back</a>
       </div>
@@ -190,7 +183,7 @@ export default function GuessChatPage() {
         <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", marginBottom: "24px", flexWrap: "wrap", gap: "12px" }}>
           <h1 style={{ fontSize: "1.5rem", fontWeight: 700 }}>Review Guesses</h1>
           <button className="btn btn-secondary" onClick={() => setReviewMode(false)}>
-            Back
+            {allDone ? "Back" : "Back to Current Grid"}
           </button>
         </div>
 
@@ -294,11 +287,22 @@ export default function GuessChatPage() {
 
   return (
     <div>
-      <div style={{ marginBottom: "24px" }}>
-        <h1 style={{ fontSize: "1.5rem", fontWeight: 700 }}>Guess Chat</h1>
-        <p style={{ color: "var(--text-secondary)", fontSize: "0.9rem" }}>
-          Grid {completedCount + 1} of {totalGrids}
-        </p>
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", marginBottom: "24px", flexWrap: "wrap", gap: "12px" }}>
+        <div>
+          <h1 style={{ fontSize: "1.5rem", fontWeight: 700 }}>Guess Chat</h1>
+          <p style={{ color: "var(--text-secondary)", fontSize: "0.9rem" }}>
+            Grid {completedCount + 1} of {totalGrids}
+          </p>
+        </div>
+        {entries.length > 0 && (
+          <button
+            className="btn btn-secondary"
+            style={{ fontSize: "0.85rem" }}
+            onClick={() => { setReviewMode(true); setReviewIndex(entries.length - 1); }}
+          >
+            Review Previous ({entries.length})
+          </button>
+        )}
       </div>
 
       {error && (


### PR DESCRIPTION
## Summary
This PR removes the restriction that prevented players from guessing their own grid submissions in the Guess Chat game mode. Players can now participate in guessing all submitted grids, including their own.

## Key Changes
- **Removed `hasOwnSubmission` state**: Eliminated the state variable and related logic that tracked whether the current player had submitted a grid
- **Updated API query**: Modified the submission grids query to include the player's own submissions (removed `AND g.created_by != ?` filter)
- **Simplified messaging**: Removed conditional messaging that displayed different text when a player had their own submission, now showing a single "No Submissions Yet" message
- **Enhanced UI**: Added a "Review Previous" button to the main Guess Chat interface that allows players to review previously guessed grids, with a dynamic button label that changes based on completion status

## Implementation Details
- The API endpoint (`/api/play/guess-chat`) no longer filters out the current user's submissions when fetching grids to guess
- Removed the separate check for the player's own submission since it's no longer needed
- The review mode now displays a count of completed entries and allows navigation back to the current grid when not all grids are completed

https://claude.ai/code/session_01Egd2ARXJ3NYctBaUFArWTY