### PR TITLE
Show grid answers after each guess-chat submission and in review mode

### DIFF
--- a/src/app/api/play/guess-chat/route.ts
+++ b/src/app/api/play/guess-chat/route.ts
@@ -50,9 +50,13 @@ export async function GET() {
     guessSession = newSession.rows[0];
   }
 
-  // Get existing entries for this session
+  // Get existing entries for this session (with grid data for display)
   const entriesResult = await db.execute({
-    sql: "SELECT * FROM guess_entries WHERE session_id = ? ORDER BY order_index",
+    sql: `SELECT ge.*, g.row_categories, g.col_categories, g.example_answers
+          FROM guess_entries ge
+          JOIN grids g ON g.id = ge.grid_id
+          WHERE ge.session_id = ?
+          ORDER BY ge.order_index`,
     args: [guessSession.id as string],
   });
 
@@ -121,6 +125,7 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: "You cannot use the same Pokémon more than once" }, { status: 400 });
   }
 
+  const isCorrect: boolean[] = Array(9).fill(false);
   let correctCount = 0;
   for (let row = 0; row < 3; row++) {
     for (let col = 0; col < 3; col++) {
@@ -130,9 +135,12 @@ export async function POST(req: NextRequest) {
           pokemonMatchesCategory(pokemon, rowCategories[row]) &&
           pokemonMatchesCategory(pokemon, colCategories[col])) {
         correctCount++;
+        isCorrect[idx] = true;
       }
     }
   }
+
+  const exampleAnswers = JSON.parse(grid.example_answers as string) as string[];
 
   // Get current entry count for order_index
   const entryCountResult = await db.execute({
@@ -159,5 +167,5 @@ export async function POST(req: NextRequest) {
     });
   }
 
-  return NextResponse.json({ correctCount });
+  return NextResponse.json({ correctCount, isCorrect, exampleAnswers });
 }

--- a/src/app/play/guess-chat/page.tsx
+++ b/src/app/play/guess-chat/page.tsx
@@ -62,6 +62,7 @@ export default function GuessChatPage() {
   // Review mode: browsing through completed entries to adjust guesses
   const [reviewMode, setReviewMode] = useState(false);
   const [reviewIndex, setReviewIndex] = useState(0);
+  const [reviewIntendedSelections, setReviewIntendedSelections] = useState<string[]>([]);
 
   const fetchSession = useCallback(() => {
     setLoading(true);
@@ -97,6 +98,12 @@ export default function GuessChatPage() {
   }, [router]);
 
   useEffect(() => { fetchSession(); }, [fetchSession]);
+
+  useEffect(() => {
+    if (reviewMode && entries[reviewIndex]) {
+      setReviewIntendedSelections(JSON.parse(entries[reviewIndex].example_answers) as string[]);
+    }
+  }, [reviewMode, reviewIndex, entries]);
 
   function getCategoryLabel(id: string): string {
     return getLabelForCategoryId(id);
@@ -287,7 +294,7 @@ export default function GuessChatPage() {
                   <div className="grid-header">{getCategoryLabel(rowId)}</div>
                   {colCategories.map((colId, c) => {
                     const idx = r * 3 + c;
-                    const selectedName = exampleAnswers[idx];
+                    const selectedName = reviewIntendedSelections[idx] || exampleAnswers[idx];
                     const validNames = getFilteredPokemonNames(rowId, colId);
                     return (
                       <div key={`intended-${r}-${c}`} className="grid-cell correct" style={{ flexDirection: "column", gap: "4px" }}>
@@ -303,9 +310,13 @@ export default function GuessChatPage() {
                         )}
                         <select
                           value={selectedName}
+                          onChange={e => {
+                            const next = [...reviewIntendedSelections];
+                            next[idx] = e.target.value;
+                            setReviewIntendedSelections(next);
+                          }}
                           style={{ fontSize: "0.7rem", padding: "2px 4px", marginTop: "2px", width: "100%" }}
                           aria-label={`Valid answers for row ${r + 1}, column ${c + 1}`}
-                          readOnly
                         >
                           {validNames.map(name => (
                             <option key={name} value={name}>{name}</option>

--- a/src/app/play/guess-chat/page.tsx
+++ b/src/app/play/guess-chat/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState, useCallback } from "react";
 import { useRouter } from "next/navigation";
-import { getLabelForCategoryId } from "@/data/pokemon";
+import { getLabelForCategoryId, getFilteredPokemonNames, getPokemonSpriteUrl, findPokemon, pokemonMatchesCategory } from "@/data/pokemon";
 import PokemonAutocomplete from "@/components/PokemonAutocomplete";
 
 interface User {
@@ -18,6 +18,9 @@ interface Entry {
   correct_count: number;
   guessed_author_id: string | null;
   order_index: number;
+  row_categories: string;
+  col_categories: string;
+  example_answers: string;
 }
 
 interface GridData {
@@ -29,6 +32,11 @@ interface GridData {
 interface SessionData {
   id: string;
   status: string;
+}
+
+interface GridResult {
+  isCorrect: boolean[];
+  exampleAnswers: string[];
 }
 
 export default function GuessChatPage() {
@@ -46,6 +54,10 @@ export default function GuessChatPage() {
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(true);
   const [submitting, setSubmitting] = useState(false);
+
+  // Result shown after submitting a grid (before moving to next)
+  const [gridResult, setGridResult] = useState<GridResult | null>(null);
+  const [intendedSelections, setIntendedSelections] = useState<string[]>(Array(9).fill(""));
 
   // Review mode: browsing through completed entries to adjust guesses
   const [reviewMode, setReviewMode] = useState(false);
@@ -113,14 +125,22 @@ export default function GuessChatPage() {
     });
 
     if (res.ok) {
-      setAnswers(Array(9).fill(""));
-      setGuessedAuthorId("");
-      fetchSession();
+      const data = await res.json();
+      setGridResult({ isCorrect: data.isCorrect, exampleAnswers: data.exampleAnswers });
+      setIntendedSelections([...data.exampleAnswers]);
     } else {
       const data = await res.json();
       setError(data.error || "Failed to submit");
     }
     setSubmitting(false);
+  }
+
+  function proceedToNext() {
+    setGridResult(null);
+    setIntendedSelections(Array(9).fill(""));
+    setAnswers(Array(9).fill(""));
+    setGuessedAuthorId("");
+    fetchSession();
   }
 
   async function updateGuess(gridId: string, newGuessId: string) {
@@ -176,8 +196,11 @@ export default function GuessChatPage() {
   // Review mode UI
   if (reviewMode && entries.length > 0) {
     const entry = entries[reviewIndex];
-    // We need grid data for review — we stored it in the entry from the API
-    // Actually we don't have row/col categories in entries. Let me show a simpler review.
+    const rowCategories = JSON.parse(entry.row_categories) as string[];
+    const colCategories = JSON.parse(entry.col_categories) as string[];
+    const playerAnswers = JSON.parse(entry.answers) as string[];
+    const exampleAnswers = JSON.parse(entry.example_answers) as string[];
+
     return (
       <div>
         <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", marginBottom: "24px", flexWrap: "wrap", gap: "12px" }}>
@@ -191,12 +214,12 @@ export default function GuessChatPage() {
           Grid {reviewIndex + 1} of {entries.length}
         </div>
 
-        <div className="card" style={{ marginBottom: "16px" }}>
+        <div className="card" style={{ marginBottom: "20px" }}>
           <div style={{ marginBottom: "12px" }}>
-            <strong>Your score:</strong> {entry.correct_count}/9
+            <strong>Score: {entry.correct_count}/9</strong>
           </div>
           <div>
-            <strong>Your guess:</strong>
+            <strong>Who created this grid?</strong>
             <div style={{ display: "flex", flexWrap: "wrap", gap: "8px", marginTop: "8px" }}>
               {users.map(u => (
                 <span
@@ -207,6 +230,91 @@ export default function GuessChatPage() {
                 >
                   {u.display_name}
                 </span>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        <div style={{ display: "flex", gap: "32px", flexWrap: "wrap", alignItems: "flex-start", marginBottom: "24px" }}>
+          {/* Player's answers */}
+          <div>
+            <h2 style={{ fontSize: "1rem", fontWeight: 600, marginBottom: "8px", color: "var(--text-secondary)" }}>Your Answers</h2>
+            <div className="pokedoku-grid">
+              <div className="grid-corner" />
+              {colCategories.map(id => (
+                <div key={id} className="grid-header">{getCategoryLabel(id)}</div>
+              ))}
+              {rowCategories.map((rowId, r) => (
+                <div key={`row-${r}`} style={{ display: "contents" }}>
+                  <div className="grid-header">{getCategoryLabel(rowId)}</div>
+                  {colCategories.map((colId, c) => {
+                    const idx = r * 3 + c;
+                    const answer = playerAnswers[idx];
+                    const pokemon = answer ? findPokemon(answer) : null;
+                    const correct = pokemon && pokemonMatchesCategory(pokemon, rowId) && pokemonMatchesCategory(pokemon, colId);
+                    return (
+                      <div key={`cell-${r}-${c}`} className={`grid-cell ${answer ? (correct ? "correct" : "incorrect") : ""}`}>
+                        <div style={{ textAlign: "center", padding: "4px" }}>
+                          {answer && (
+                            <>
+                              <img
+                                src={getPokemonSpriteUrl(answer) || ""}
+                                alt={answer}
+                                style={{ width: "40px", height: "40px", imageRendering: "pixelated", display: "block", margin: "0 auto 2px" }}
+                              />
+                              <span style={{ fontSize: "0.75rem" }}>{answer}</span>
+                            </>
+                          )}
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* Intended answers */}
+          <div>
+            <h2 style={{ fontSize: "1rem", fontWeight: 600, marginBottom: "8px", color: "var(--text-secondary)" }}>Intended Answers</h2>
+            <div className="pokedoku-grid">
+              <div className="grid-corner" />
+              {colCategories.map(id => (
+                <div key={id} className="grid-header">{getCategoryLabel(id)}</div>
+              ))}
+              {rowCategories.map((rowId, r) => (
+                <div key={`row-${r}`} style={{ display: "contents" }}>
+                  <div className="grid-header">{getCategoryLabel(rowId)}</div>
+                  {colCategories.map((colId, c) => {
+                    const idx = r * 3 + c;
+                    const selectedName = exampleAnswers[idx];
+                    const validNames = getFilteredPokemonNames(rowId, colId);
+                    return (
+                      <div key={`intended-${r}-${c}`} className="grid-cell correct" style={{ flexDirection: "column", gap: "4px" }}>
+                        {selectedName && (
+                          <>
+                            <img
+                              src={getPokemonSpriteUrl(selectedName) || ""}
+                              alt={selectedName}
+                              style={{ width: "40px", height: "40px", imageRendering: "pixelated" }}
+                            />
+                            <span style={{ fontSize: "0.75rem", textAlign: "center" }}>{selectedName}</span>
+                          </>
+                        )}
+                        <select
+                          value={selectedName}
+                          style={{ fontSize: "0.7rem", padding: "2px 4px", marginTop: "2px", width: "100%" }}
+                          aria-label={`Valid answers for row ${r + 1}, column ${c + 1}`}
+                          readOnly
+                        >
+                          {validNames.map(name => (
+                            <option key={name} value={name}>{name}</option>
+                          ))}
+                        </select>
+                      </div>
+                    );
+                  })}
+                </div>
               ))}
             </div>
           </div>
@@ -284,6 +392,117 @@ export default function GuessChatPage() {
 
   const rowCategories = JSON.parse(nextGrid.row_categories) as string[];
   const colCategories = JSON.parse(nextGrid.col_categories) as string[];
+
+  // Result view after submitting current grid
+  if (gridResult) {
+    return (
+      <div>
+        <div style={{ marginBottom: "24px" }}>
+          <h1 style={{ fontSize: "1.5rem", fontWeight: 700 }}>Guess Chat</h1>
+          <p style={{ color: "var(--text-secondary)", fontSize: "0.9rem" }}>
+            Grid {completedCount} of {totalGrids}
+          </p>
+        </div>
+
+        <div className="card" style={{ marginBottom: "24px", textAlign: "center" }}>
+          <div style={{ fontSize: "2.5rem", fontWeight: 800, color: gridResult.isCorrect.filter(Boolean).length >= 7 ? "var(--success)" : gridResult.isCorrect.filter(Boolean).length >= 4 ? "var(--warning)" : "var(--accent)" }}>
+            {gridResult.isCorrect.filter(Boolean).length}/9
+          </div>
+          <p style={{ color: "var(--text-secondary)" }}>cells correct</p>
+        </div>
+
+        <div style={{ display: "flex", gap: "32px", flexWrap: "wrap", alignItems: "flex-start", marginBottom: "24px" }}>
+          {/* Player's grid */}
+          <div>
+            <h2 style={{ fontSize: "1rem", fontWeight: 600, marginBottom: "8px", color: "var(--text-secondary)" }}>Your Answers</h2>
+            <div className="pokedoku-grid">
+              <div className="grid-corner" />
+              {colCategories.map(id => (
+                <div key={id} className="grid-header">{getCategoryLabel(id)}</div>
+              ))}
+              {rowCategories.map((rowId, r) => (
+                <div key={`row-${r}`} style={{ display: "contents" }}>
+                  <div className="grid-header">{getCategoryLabel(rowId)}</div>
+                  {colCategories.map((_colId, c) => {
+                    const idx = r * 3 + c;
+                    return (
+                      <div key={`cell-${r}-${c}`} className={`grid-cell ${gridResult.isCorrect[idx] ? "correct" : "incorrect"}`}>
+                        <div style={{ textAlign: "center", padding: "4px" }}>
+                          {answers[idx] && (
+                            <>
+                              <img
+                                src={getPokemonSpriteUrl(answers[idx]) || ""}
+                                alt={answers[idx]}
+                                style={{ width: "40px", height: "40px", imageRendering: "pixelated", display: "block", margin: "0 auto 2px" }}
+                              />
+                              <span style={{ fontSize: "0.75rem" }}>{answers[idx]}</span>
+                            </>
+                          )}
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* Intended answers */}
+          <div>
+            <h2 style={{ fontSize: "1rem", fontWeight: 600, marginBottom: "8px", color: "var(--text-secondary)" }}>Intended Answers</h2>
+            <div className="pokedoku-grid">
+              <div className="grid-corner" />
+              {colCategories.map(id => (
+                <div key={id} className="grid-header">{getCategoryLabel(id)}</div>
+              ))}
+              {rowCategories.map((rowId, r) => (
+                <div key={`row-${r}`} style={{ display: "contents" }}>
+                  <div className="grid-header">{getCategoryLabel(rowId)}</div>
+                  {colCategories.map((colId, c) => {
+                    const idx = r * 3 + c;
+                    const selectedName = intendedSelections[idx] || gridResult.exampleAnswers[idx];
+                    const validNames = getFilteredPokemonNames(rowId, colId);
+                    return (
+                      <div key={`intended-${r}-${c}`} className="grid-cell correct" style={{ flexDirection: "column", gap: "4px" }}>
+                        {selectedName && (
+                          <>
+                            <img
+                              src={getPokemonSpriteUrl(selectedName) || ""}
+                              alt={selectedName}
+                              style={{ width: "40px", height: "40px", imageRendering: "pixelated" }}
+                            />
+                            <span style={{ fontSize: "0.75rem", textAlign: "center" }}>{selectedName}</span>
+                          </>
+                        )}
+                        <select
+                          value={selectedName}
+                          onChange={e => {
+                            const next = [...intendedSelections];
+                            next[idx] = e.target.value;
+                            setIntendedSelections(next);
+                          }}
+                          style={{ fontSize: "0.7rem", padding: "2px 4px", marginTop: "2px", width: "100%" }}
+                          aria-label={`Valid answers for row ${r + 1}, column ${c + 1}`}
+                        >
+                          {validNames.map(name => (
+                            <option key={name} value={name}>{name}</option>
+                          ))}
+                        </select>
+                      </div>
+                    );
+                  })}
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        <button className="btn btn-primary" onClick={proceedToNext}>
+          Next Grid
+        </button>
+      </div>
+    );
+  }
 
   return (
     <div>


### PR DESCRIPTION
- After submitting a grid in guess-chat, show the same result view as normal play mode: score card, your answers with correct/incorrect cell coloring + sprites, and the intended answers grid with valid Pokémon selector; a "Next Grid" button advances rather than auto-advancing immediately
- Review mode now shows the full grid (categories + your filled answers with correct/incorrect coloring and sprites) and the intended answers alongside the author guess picker
- API GET now joins guess_entries with grids to include row_categories, col_categories, example_answers in each entry
- API POST now returns isCorrect[] and exampleAnswers[] like the solve endpoint does

https://claude.ai/code/session_01Egd2ARXJ3NYctBaUFArWTY